### PR TITLE
Makefile/travis.yml/build.sh: updatedeps fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ branches:
   only:
     - master
 
-install: make updatedeps
-#  - true
+install:
+ - true
 
 script:
   - make

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ testrace: generate
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.
 vet:
+	@go tool vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
+		go get golang.org/x/tools/cmd/vet; \
+	fi
 	@go list -f '{{.Dir}}' ./... | grep -v /vendor/) \
 		| grep -v '.*github.com/hashicorp/vault-ssh-helper$$' \
 		| xargs go tool vet ; if [ $$? -eq 1 ]; then \
@@ -54,7 +57,7 @@ generate:
 updatedeps:
 	go get -u github.com/mitchellh/gox
 	go get -u golang.org/x/tools/cmd/vet
-	$(go list ./... | grep -v /vendor/) \
+	echo $$(go list ./... | grep -v /vendor/) \
 		| xargs go list -f '{{ join .Deps "\n" }}{{ printf "\n" }}{{ join .TestImports "\n" }}' \
 		| grep -v github.com/hashicorp/$(NAME) \
 		| xargs go get -f -u -v

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,6 +38,11 @@ if [ "${DEV}x" != "x" ]; then
     XC_ARCH=$(go env GOARCH)
 fi
 
+if ! which gox > /dev/null; then
+    echo "==> Installing gox..."
+    go get -u github.com/mitchellh/gox
+fi
+
 # Build!
 echo "==> Building..."
 gox \


### PR DESCRIPTION
 - Makefile had a typo in the `updatedeps` definition which was failing
   the travis build; we fix that up here.
 - Additionally, with vendored deps, travis doesn't need to run
   updatdeps at all! I seem to recall a Travis gotahcya where if an
   install clause is not specifies some unwanted automagic commands are
   run, so left the `true` in there to avoid that.
 - Add JIT installation of `go vet` and `gox` to relevant places.