### PR TITLE
Allowed Roles for Default Config Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ Sample `config.hcl`:
 vault_addr = "https://vault.example.com:8200"
 ssh_mount_point = "ssh"
 ca_cert = "/etc/vault-ssh-helper.d/vault.crt"
-tls_skip_verify=false
+tls_skip_verify = false
+allowed_roles = "*"
 ```
 
 PAM Configuration


### PR DESCRIPTION
The README is missing the developer setting for any role.