### PR TITLE
Make usage exit 1

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func Run(args []string) error {
 
 	flags.Usage = func() {
 		fmt.Printf("%s\n", Help())
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	if err := flags.Parse(args); err != nil {


### PR DESCRIPTION
Usage() os.Exit(0) caused users to be able to log in using any password when vault-ssh-helpers was updated and argument -config-file changed to -config and pam.d sshd config was using the old -config-file argument to the helper.

This updated/error goes easily unnoticed as the vault one time passwords keep working (as do any string passed in as password.) Also the exit 0 on usage makes it easy to miss configure the helper for open access.

```Nov  8 11:00:09 ip-172-18-3-152 sshd[2934]: Postponed keyboard-interactive for admin from 185.11.209.162 port 60685 ssh2 [preauth]
Nov  8 11:00:10 ip-172-18-3-152 sshd[2936]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=x.x.x.x  user=admin
Nov  8 11:00:10 ip-172-18-3-152 sshd[2934]: Postponed keyboard-interactive/pam for admin from 1x.x.x.x port 60685 ssh2 [preauth]
Nov  8 11:00:10 ip-172-18-3-152 sshd[2934]: Accepted keyboard-interactive/pam for admin from x.x.x.x port 60685 ssh2
Nov  8 11:00:10 ip-172-18-3-152 sshd[2934]: pam_unix(sshd:session): session opened for user admin by (uid=0)
Nov  8 11:00:10 ip-172-18-3-152 systemd: pam_unix(systemd-user:session): session opened for user admin by (uid=0)
Nov  8 11:00:10 ip-172-18-3-152 systemd-logind[557]: New session 15 of user admin.
``` 
and vault ssh helper log 

```*** Wed Nov  8 11:00:10 2017
flag provided but not defined: -config-file
Usage: vault-ssh-helper [options]

  vault-ssh-helper takes the One-Time-Password (OTP) from the client and
  validates it with Vault server. This binary should be used as an external
  command for authenticating clients during for keyboard-interactive auth
  of SSH server.

Options:

  -config=<path>              The path on disk to a configuration file.
  -dev                        Run the helper in "dev" mode, (such as testing or http)
  -verify-only                Verify the installation and communication with Vault server
  -version                    Display version.
```