### PR TITLE
Allow wildcards in allowed_roles

### DIFF
--- a/helper/agent_test.go
+++ b/helper/agent_test.go
@@ -32,3 +32,23 @@ func TestBelongsToCIDR(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
+
+func TestValidateRoleName(t *testing.T) {
+	allowedRoles := "*"
+	err := validateRoleName("foo", allowedRoles)
+	if err != nil {
+		t.Fatalf("Role 'foo' not found in %s", allowedRoles)
+	}
+
+	allowedRoles = "bar, foo"
+	err = validateRoleName("foo", allowedRoles)
+	if err != nil {
+		t.Fatalf("Role 'foo' not found in %s", allowedRoles)
+	}
+
+	allowedRoles = "f*"
+	err = validateRoleName("foo", allowedRoles)
+	if err != nil {
+		t.Fatalf("Role 'foo' not found in %s", allowedRoles)
+	}
+}


### PR DESCRIPTION
This PR allows to match SSH role using wildcards. So, in the vault-ssh-helper hcl config file we can have something like this:

```
vault_addr = "https://vault.example.com"
allowed_roles = "some_fixed_string-*"
...
```

In Vault we can have SSH roles like `some_fixed_string-admins`, `some_fixed_string-users` etc and any OTP from one of these roles can authenticate in this machine:

```
...
2019/02/28 09:29:19 roles: [some_fixed_string-*]
2019/02/28 09:29:19 some_fixed_string-* matches some_fixed_string-user
2019/02/28 09:29:19 [INFO] user@A.B.C.D authenticated!
```

Thanks!