### PR TITLE
Update validateIP function to actually do a match for a singe IP Address

### DIFF
--- a/helper/agent_test.go
+++ b/helper/agent_test.go
@@ -5,6 +5,48 @@ import (
 	"testing"
 )
 
+func TestValidateIP(t *testing.T) {
+	t.Parallel()
+	// This allows the testing of the validateIP function
+	netInterfaceAddrs = func() ([]net.Addr, error) {
+		var ips []net.Addr
+		var err error
+		//var ip net.IP
+		ips = append(ips, &net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)})
+		ips = append(ips, &net.IPNet{IP: net.ParseIP("10.50.100.101"), Mask: net.CIDRMask(24, 32)})
+		ips = append(ips, &net.IPNet{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)})
+
+		return ips, err
+	}
+	var testIP string
+	var testCIDR string
+	var err error
+
+	testIP = "10.50.100.101"
+	testCIDR = ""
+	err = validateIP(testIP, testCIDR)
+	// Pass if err == nil
+	if err != nil {
+		t.Fatalf("Actual IP Match: expected nill, actual: %s", err)
+	}
+
+	testIP = "10.50.100.102"
+	testCIDR = "10.50.100.0/24"
+	err = validateIP(testIP, testCIDR)
+	// Pass if err == nil
+	if err != nil {
+		t.Fatalf("IP in CIDR: expected nill, actual: %s", err)
+	}
+
+	testIP = "10.50.100.102"
+	testCIDR = ""
+	err = validateIP(testIP, testCIDR)
+	// Fail if err == nil
+	if err == nil {
+		t.Fatalf("IP Does Not Match: expected error, actual: nil")
+	}
+
+}
 func TestBelongsToCIDR(t *testing.T) {
 	t.Parallel()
 	testIP := net.ParseIP("10.50.100.101")


### PR DESCRIPTION
net.Interfaces() and net.InterfaceAddrs() actually returns the IP address and Mask (192.168.2.4/24).  This means that any IP address that was in the same IP subnet of the authorized IP address would match with the previous logic


Issue: #47