### PR TITLE
update SSHD configuration - `KbdInteractiveAuthentication`

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,14 +190,14 @@ are the default options; you may not need to set them explicitly but should
 verify their values if not.
 
 ```
-ChallengeResponseAuthentication yes
+KbdInteractiveAuthentication yes
 UsePAM yes
 PasswordAuthentication no
 ```
 
 |Option                               |Description |
 |-------------------------------------|------------|
-|`ChallengeResponseAuthentication yes`|[Required] Enable challenge response (keyboard-interactive) authentication.
+|`KbdInteractiveAuthentication yes`|[Required] Enable challenge response (keyboard-interactive) authentication.
 |`UsePAM yes`                         |[Required] Enable PAM authentication modules.
 |`PasswordAuthentication no`          |Disable password authentication.
 


### PR DESCRIPTION
Replace the deprecated `ChallengeResponseAuthentication` with `KbdInteractiveAuthentication`

https://www.openssh.com/txt/release-8.7 (2021-08-20):
```console
 * ssh(1)/sshd(8): remove references to ChallengeResponseAuthentication
   in favour of KbdInteractiveAuthentication. The former is what was in
   SSHv1, the latter is what is in SSHv2 (RFC4256) and they were
   treated as somewhat but not entirely equivalent. We retain the old
   name as a deprecated alias so configuration files continue to work
   as well as a reference in the man page for people looking for it.
   bz#3303
```