### PR TITLE
Convert release config to v2 schema

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -28,65 +28,17 @@ event "build" {
 
   depends = ["merge"]
 }
-event "upload-dev" {
+event "prepare" {
 
-  action "upload-dev" {
+  action "prepare" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
-    workflow     = "upload-dev"
+    workflow     = "prepare"
     depends      = ["build"]
     config       = ""
   }
 
   depends = ["build"]
-
-  notification {
-    on = "fail"
-  }
-}
-event "security-scan-binaries" {
-
-  action "security-scan-binaries" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "security-scan-binaries"
-    depends      = null
-    config       = "security-scan.hcl"
-  }
-
-  depends = ["upload-dev"]
-
-  notification {
-    on = "fail"
-  }
-}
-event "sign" {
-
-  action "sign" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "sign"
-    depends      = null
-    config       = ""
-  }
-
-  depends = ["security-scan-binaries"]
-
-  notification {
-    on = "fail"
-  }
-}
-event "verify" {
-
-  action "verify" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "verify"
-    depends      = null
-    config       = ""
-  }
-
-  depends = ["sign"]
 
   notification {
     on = "fail"


### PR DESCRIPTION
### Summary 
 This PR intends to convert the release config to the v2 schema as part of the promotion pipeline updates. 

 There are three distinct changes to the `ci.hcl` config file: 
 1. The `schema` version is upgraded to `2` to match the updates 
 2. `promote-*-packaging` and `promote-*-docker` event blocks are removed: these will be automatically run if the corresponding artifacts are built and available in `artifactory`
 3. Optional workflows (`update-ironbank`, `bump-version`, `post-publish-website`, `promote-helm`, `pre-promotion-workflows` and `post-promotion-workflows`) are added as fields in the `promotion-events` block based on what is defined in the current `ci.hcl`

 You can read more about the promotion pipeline updates [here](https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2905604117/February+13+2024+-+Simplified+Promotion+Pipeline).