### PR TITLE
Bump project version to 0.2.3. Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,14 @@
 ## Unreleased
 
+## 0.2.3 (May 28, 2026)
+
 IMPROVEMENTS:
+
+* Added support for linux/s390x architecture.
 
 * Added `-log-level` command-line option [GH-77](https://github.com/hashicorp/vault-ssh-helper/pull/77)
 
-CHANGES:
-
-* Building with Go 1.21.4
-* Updated golang dependencies [GH-71](https://github.com/hashicorp/vault-ssh-helper/pull/71)
-  * golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 => v0.16.0
-  * golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c => v0.15.0
-  * golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 => v0.19.0
-  * golang.org/x/text v0.3.3 => v0.14.0
-  * github.com/hashicorp/go-hclog v1.4.0 => v1.5.0
-  * github.com/hashicorp/go-uuid v1.0.2 => v1.0.3
-  * github.com/hashicorp/vault/api v1.4.1 => v1.10.0
-  * github.com/go-jose/go-jose/v3 v3.0.0 => v3.0.1
+## 0.2.2 (unreleased)
 
 ## 0.2.1 (December 15, 2020)
 

--- a/version.go
+++ b/version.go
@@ -11,7 +11,7 @@ import (
 var GitCommit string
 
 const Name = "vault-ssh-helper"
-const Version = "0.2.1"
+const Version = "0.2.3"
 const VersionPrerelease = ""
 
 // formattedVersion returns a formatted version string which includes the git


### PR DESCRIPTION
In preparation to issue a new release to add support for linux/s309x architecture, bump project version to 0.2.3.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
