### PR TITLE
Bump version to 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 ## Unreleased
 
-## 0.2.3 (May 28, 2026)
+## 0.2.4 (May 28, 2026)
 
 IMPROVEMENTS:
 
-* Added support for linux/s390x architecture.
+* Added support for linux/s390x and linux/arm64 architectures.
 
 * Added `-log-level` command-line option [GH-77](https://github.com/hashicorp/vault-ssh-helper/pull/77)
+
+## 0.2.3 (unreleased)
 
 ## 0.2.2 (unreleased)
 

--- a/version.go
+++ b/version.go
@@ -11,7 +11,7 @@ import (
 var GitCommit string
 
 const Name = "vault-ssh-helper"
-const Version = "0.2.3"
+const Version = "0.2.4"
 const VersionPrerelease = ""
 
 // formattedVersion returns a formatted version string which includes the git


### PR DESCRIPTION
Bump version to 0.2.4, as I created the tag for v0.2.3 incorrectly.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
